### PR TITLE
Fix - improve IconButton sizing + full width LinkBase + add IconButton style

### DIFF
--- a/ui-react/src/atoms/iconButton/buildTheme.ts
+++ b/ui-react/src/atoms/iconButton/buildTheme.ts
@@ -78,11 +78,33 @@ export const buildIconButtonThemes = (colors: IColorGuide, dimensions: IDimensio
     },
   }, base?.secondary);
 
+  const smallIconButtonTheme = mergeThemePartial<IIconButtonTheme>({
+    normal: {
+      default: {
+        background: {
+          'padding': `${dimensions.paddingNarrow} ${dimensions.paddingNarrow}`,
+        },
+      },
+    },
+  }, base?.secondary);
+
+  const passiveIconButtonTheme = mergeThemePartial<IIconButtonTheme>({
+    normal: {
+      default: {
+        text: {
+          'color': '$colors.textLight50',
+        },
+      },
+    },
+  }, base?.secondary);
+
   return {
     ...base,
     default: defaultIconButtonTheme,
     primary: primaryIconButtonTheme,
     secondary: secondaryIconButtonTheme,
     tertiary: defaultIconButtonTheme,
+    small: smallIconButtonTheme,
+    passive: passiveIconButtonTheme,
   };
 }

--- a/ui-react/src/atoms/iconButton/component.tsx
+++ b/ui-react/src/atoms/iconButton/component.tsx
@@ -62,8 +62,10 @@ export interface IIconButtonProps extends IComponentProps<IIconButtonTheme> {
 }
 
 export const IconButton = (props: IIconButtonProps): React.ReactElement => {
-  const onClicked = (): void => {
+  const onClicked = (event: React.SyntheticEvent): void => {
     if (props.onClicked) {
+      console.log('here');
+      event.stopPropagation();
       props.onClicked();
     }
   };

--- a/ui-react/src/atoms/linkBase/component.tsx
+++ b/ui-react/src/atoms/linkBase/component.tsx
@@ -21,7 +21,7 @@ const StyledLinkBase = styled.a<IStyledLinkBaseProps>`
   background-clip: padding-box;
   transition: 0.3s;
   width: fit-content;
-  .fullWidth {
+  &.fullWidth {
     width: 100%;
   }
 

--- a/ui-react/src/subatoms/icon/component.tsx
+++ b/ui-react/src/subatoms/icon/component.tsx
@@ -18,10 +18,12 @@ const StyledIcon = styled.div<IStyledIconProps>`
   min-width: ${(props: IStyledIconProps): string => props.theme.size};
   min-height: ${(props: IStyledIconProps): string => props.theme.size};
   color: ${(props: IStyledIconProps): string => props.color ? props.color : 'currentColor'};
+  overflow: hidden;
 
   svg {
     height: 100%;
     width: 100%;
+    display: block;
     fill: ${(props: IStyledIconProps): string => props.shouldAddFill ? 'currentColor': 'none'};
     stroke: ${(props: IStyledIconProps): string => props.shouldAddStroke ? 'currentColor': 'none'};
   }

--- a/ui-react/src/subatoms/kibaIcon/documentation.stories.mdx
+++ b/ui-react/src/subatoms/kibaIcon/documentation.stories.mdx
@@ -56,6 +56,18 @@ export const Template = (args) => (
   </Story>
 </Canvas>
 
+<Canvas>
+  <Story name='Small Icon'>
+    <KibaIcon variant='small' iconId={'remix-honour'} />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name='Large Icon'>
+    <KibaIcon variant='large' iconId={'remix-honour'} />
+  </Story>
+</Canvas>
+
 ### Theming
 
 See [Icon]()


### PR DESCRIPTION
<!--- Title format: [Feature | Fix | Task#] - <summary of your changes> -->

## Description

<!--- Describe your changes in detail -->
The icon buttons were rendering off-center when using the "small" variant, which adding `display: box` fixes.
Also, LinkBase components weren't being rendered properly in full width due to the missing `&` in the styled component.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Small issues found whilst updating everypage.

## Screenshots:

<!--- If not relevant delete the sub-heading above -->

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the CHANGELOG with a summary of my changes
- [x] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
