### PR TITLE
Feature - update useBuiltTheme to defer resolving values (for SSR on IE11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - [MINOR] Rename crop to cover for fitType in Image
 - [MINOR] Update global no-js class to work with SSR by adding `isRehydrating` prop to `KibaApp`
 - [MINOR] Update `Image` and `Video` to not populate `data-src` if not lazy-loading
+- [PATCH] Update useBuiltTheme to defer resolving values (for SSR on IE11)
 
 ### Removed
 

--- a/src/atoms/linkBase/buildTheme.ts
+++ b/src/atoms/linkBase/buildTheme.ts
@@ -21,7 +21,7 @@ export const buildLinkBaseThemes = (colors: IColorGuide, dimensions: IDimensionG
       },
       press: {
         background: {
-          'background-color': '$colors.brandPrimaryClear60',
+          'background-color': '$colors.brandPrimaryClear50',
         },
       },
       focus: {

--- a/src/util/theme.ts
+++ b/src/util/theme.ts
@@ -27,6 +27,10 @@ export const themeToCss = (theme?: CssTheme): string => {
     return '';
   }
   const output = Object.keys(theme).map((key: string): string => {
+    if (!(key in theme) || !theme[key]) {
+      console.error(`key: ${key} missing in theme: ${theme}`);
+      return '';
+    }
     return `${key}: ${valueToCss(theme[key])};`;
   });
   return output.join('\n');


### PR DESCRIPTION
## Description

Previously the SSSR'ed html and the hydrated html were different because IE11 requires the value. Now they are the same because it won't resolve on first pass and will cause a re-render once everything is hydrated.

<!--- Describe your changes -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots:

<!--- If not relevant delete the sub-heading above -->

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the CHANGELOG with a summary of my changes
- [x] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
