### PR TITLE
Fix - Update `Box` to align children correctly when not full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 
 ### Changed
-- [MINOR] Fix `Box` to align children correctly when not full width
+- [PATCH] Fix `Box` to align children correctly when not full width
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 
 ### Changed
+- [MINOR] Fix `Box` to align children correctly when not full width
 
 ### Removed
 

--- a/src/particles/box/component.tsx
+++ b/src/particles/box/component.tsx
@@ -25,6 +25,7 @@ const StyledBox = styled.div<IStyledBoxProps>`
   max-height: ${(props: IStyledBoxProps): string => props.maxHeight};
   max-width: ${(props: IStyledBoxProps): string => props.maxWidth};
   display: ${(props: IStyledBoxProps): string => props.blockType};
+  flex-direction: column;
   z-index: ${(props: IStyledBoxProps): string => (props.zIndex ? `${props.zIndex}` : 'auto')};
   &.clipContent {
     overflow: hidden;


### PR DESCRIPTION
<!--- Title format: [Feature | Fix | Task#]: <summary of your changes> -->

## Description

<!--- Describe your changes -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots:

<!--- If not relevant delete the sub-heading above -->

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
