### PR TITLE
Feature: Update  GET  request to HEAD request in media component

### DIFF
--- a/src/particles/media/component.tsx
+++ b/src/particles/media/component.tsx
@@ -52,8 +52,8 @@ export const Media = (props: IMediaProps): React.ReactElement => {
         setMediaType(contentTypeParts[0]);
       })
       .catch((error : Error) => {
+        console.error(error);
         setMediaType(null);
-        console.log(error);
       });
   }, [props.source]);
 

--- a/src/particles/media/component.tsx
+++ b/src/particles/media/component.tsx
@@ -35,7 +35,7 @@ export const Media = (props: IMediaProps): React.ReactElement => {
       return;
     }
     fetch(props.source, { method: 'HEAD' })
-      .then((response : Response) => {
+      .then((response: Response) => {
         if (response.status >= 300) {
           throw new Error(`Failed to fetch content type: ${response}`);
         }
@@ -51,7 +51,7 @@ export const Media = (props: IMediaProps): React.ReactElement => {
         }
         setMediaType(contentTypeParts[0]);
       })
-      .catch((error : Error) => {
+      .catch((error: Error) => {
         console.error(error);
         setMediaType(null);
       });

--- a/src/particles/media/component.tsx
+++ b/src/particles/media/component.tsx
@@ -34,7 +34,7 @@ export const Media = (props: IMediaProps): React.ReactElement => {
       setMediaType(null);
       return;
     }
-    fetch(props.source)
+    fetch(props.source, { method: 'HEAD' })
       .then((response : Response) => {
         if (response.status >= 300) {
           throw new Error(`Failed to fetch content type: ${response}`);
@@ -51,8 +51,9 @@ export const Media = (props: IMediaProps): React.ReactElement => {
         }
         setMediaType(contentTypeParts[0]);
       })
-      .catch(() => {
+      .catch((error : Error) => {
         setMediaType(null);
+        console.log(error);
       });
   }, [props.source]);
 


### PR DESCRIPTION


## Description

The request type in the media component to check the content-type should be HEAD request and not GET. Also, the catch block should log the error.



## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
