### PR TITLE
Feature: Add sizeResponsive example to Grid documentation

### DIFF
--- a/src/layouts/grid/documentation.stories.mdx
+++ b/src/layouts/grid/documentation.stories.mdx
@@ -154,6 +154,25 @@ export const Template = (args) => (
   </Story>
 </Canvas>
 
+<Canvas>
+ <Story name='Responsive Grid'>
+    <Box>
+      <Text>Boxes that are Responsive</Text>
+      <Grid shouldAddGutters={true}>
+        <Grid.Item  sizeResponsive={{base:6 , medium:4}}>
+          <Box variant='card' isFullWidth={true}/>
+        </Grid.Item>
+        <Grid.Item  sizeResponsive={{base:6 , medium:4}}>
+          <Box variant='card' isFullWidth={true}/>
+        </Grid.Item>
+        <Grid.Item  sizeResponsive={{base:6 , medium:4}}>
+          <Box variant='card' isFullWidth={true}/>
+        </Grid.Item>
+      </Grid>
+    </Box>
+  </Story>
+</Canvas>
+
 ### Theming
 
 TODO


### PR DESCRIPTION

## Description
An example to show how to use `sizeResponsive` in Grid.

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the CHANGELOG with a summary of my changes
- [x] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
