### PR TITLE
Fix: update colors theme creation to calculate text and textOnBrand correctly + Update `InputWrapper` to set placeholder on correct elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased]
 
 ### Added
-- [MINOR] Added `HeadProvider` and `Head` to replace Helmet in apps
 
 ### Changed
-- [MINOR] Updated `Linkbase` to work with core-routing
-- [MINOR] Updated `Link` to work with core-routing
-- [MINOR] Updated `Button` to work with core-routing
-- [MINOR] Updated `IconButton` to work with core-routing
-- [MINOR] Updated `KibaApp` to wrap children with a `HeadProvider`
-- [MINOR] Updated `KibaApp` to load theme fonts
+- [MINOR] Fixed colors theme creation to calculate text and textOnBrand correctly when background is dark
+- [MINOR] Fixed `InputWrapper` to set placeholder on correct elements
 
 ### Removed
 

--- a/src/atoms/inputWrapper/component.tsx
+++ b/src/atoms/inputWrapper/component.tsx
@@ -35,7 +35,7 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
     transition-duration: 0.3s;
   }
 
-  & ::placeholder, .wrapped-input:empty::before {
+  & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
     ${(props) => themeToCss(props.theme.normal.default.placeholderText)};
   }
 
@@ -43,7 +43,7 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
     box-shadow: none;
     ${(props) => themeToCss(props.theme.normal.hover.text)};
     ${(props) => themeToCss(props.theme.normal.hover.background)};
-    & ::placeholder, .wrapped-input:empty::before {
+    & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
       ${(props) => themeToCss(props.theme.normal.hover.placeholderText)};
     }
   }
@@ -51,7 +51,7 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
   &.focus, &:focus {
     ${(props) => themeToCss(props.theme.normal.focus.text)};
     ${(props) => themeToCss(props.theme.normal.focus.background)};
-    & ::placeholder, .wrapped-input:empty::before {
+    & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
       ${(props) => themeToCss(props.theme.normal.focus.placeholderText)};
     }
   }
@@ -61,14 +61,14 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
     pointer-events: none;
     ${(props) => themeToCss(props.theme.disabled.default?.text)};
     ${(props) => themeToCss(props.theme.disabled.default?.background)};
-    & ::placeholder, .wrapped-input:empty::before {
+    & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
       ${(props) => themeToCss(props.theme.disabled.default?.placeholderText)};
     }
 
     &:hover {
       ${(props) => themeToCss(props.theme.disabled.hover.text)};
       ${(props) => themeToCss(props.theme.disabled.hover.background)};
-      & ::placeholder, .wrapped-input:empty::before {
+      & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
         ${(props) => themeToCss(props.theme.disabled.hover.placeholderText)};
       }
     }
@@ -76,7 +76,7 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
     &.focus, &:focus {
       ${(props) => themeToCss(props.theme.disabled.focus.text)};
       ${(props) => themeToCss(props.theme.disabled.focus.background)};
-      & ::placeholder, .wrapped-input:empty::before {
+      & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
         ${(props) => themeToCss(props.theme.disabled.focus.placeholderText)};
       }
     }

--- a/src/atoms/inputWrapper/component.tsx
+++ b/src/atoms/inputWrapper/component.tsx
@@ -35,7 +35,7 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
     transition-duration: 0.3s;
   }
 
-  & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
+  & ::placeholder, & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
     ${(props) => themeToCss(props.theme.normal.default.placeholderText)};
   }
 
@@ -43,7 +43,7 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
     box-shadow: none;
     ${(props) => themeToCss(props.theme.normal.hover.text)};
     ${(props) => themeToCss(props.theme.normal.hover.background)};
-    & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
+    & ::placeholder, & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
       ${(props) => themeToCss(props.theme.normal.hover.placeholderText)};
     }
   }
@@ -51,7 +51,7 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
   &.focus, &:focus {
     ${(props) => themeToCss(props.theme.normal.focus.text)};
     ${(props) => themeToCss(props.theme.normal.focus.background)};
-    & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
+    & ::placeholder, & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
       ${(props) => themeToCss(props.theme.normal.focus.placeholderText)};
     }
   }
@@ -61,14 +61,14 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
     pointer-events: none;
     ${(props) => themeToCss(props.theme.disabled.default?.text)};
     ${(props) => themeToCss(props.theme.disabled.default?.background)};
-    & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
+    & ::placeholder, & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
       ${(props) => themeToCss(props.theme.disabled.default?.placeholderText)};
     }
 
     &:hover {
       ${(props) => themeToCss(props.theme.disabled.hover.text)};
       ${(props) => themeToCss(props.theme.disabled.hover.background)};
-      & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
+      & ::placeholder, & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
         ${(props) => themeToCss(props.theme.disabled.hover.placeholderText)};
       }
     }
@@ -76,7 +76,7 @@ const InputWrapperInner = styled.div<IInputWrapperInnerProps>`
     &.focus, &:focus {
       ${(props) => themeToCss(props.theme.disabled.focus.text)};
       ${(props) => themeToCss(props.theme.disabled.focus.background)};
-      & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
+      & ::placeholder, & input ::placeholder, & textarea ::placeholder, .wrapped-input:empty::before {
         ${(props) => themeToCss(props.theme.disabled.focus.placeholderText)};
       }
     }

--- a/src/particles/colors/buildTheme.ts
+++ b/src/particles/colors/buildTheme.ts
@@ -15,8 +15,8 @@ export const buildColors = (base?: Partial<IColorGuide>): IColorGuide => {
   const brandPrimary = base?.brandPrimary || '#333333';
   const brandSecondary = base?.brandSecondary || darken(0.2, brandPrimary);
   const background = base?.background || '#f5f5f5';
-  const text = base?.text || getLuminance(background) > 0.5 ? '#222222' : '#eeeeee';
-  const textOnBrand = base?.textOnBrand || getLuminance(brandPrimary) > 0.5 ? '#222222' : '#eeeeee';
+  const text = base?.text || (getLuminance(background) > 0.5 ? '#222222' : '#eeeeee');
+  const textOnBrand = base?.textOnBrand || (getLuminance(brandPrimary) > 0.5 ? '#222222' : '#eeeeee');
   const disabled = base?.disabled || '#777777';
   const disabledText = base?.disabledText || '#444444';
   const error = base?.error || '#ff0033';


### PR DESCRIPTION
<!--- Title format: [Feature | Fix | Task#]: <summary of your changes> -->

## Description

<!--- Describe your changes -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots:

<!--- If not relevant delete the sub-heading above -->

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
