### PR TITLE
Feature: Trust image extension in Media if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - [MINOR] Added `background` prop to `KibaApp`
 - [MINOR] Created `renderHead` for external head rendering
-- [MINOR] updated `media` to check for url extension and trust if present before checking for content-type
+- [MINOR] updated `Media` to check for url extension and trust if present before checking for content-type
 
 ### Changed
 - [MINOR] Fixed colors theme creation to calculate text and textOnBrand correctly when background is dark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - [MINOR] Added `background` prop to `KibaApp`
 - [MINOR] Created `renderHead` for external head rendering
+- [MINOR] updated `media` to check for url extension and trust if present before checking for content-type
 
 ### Changed
 - [MINOR] Fixed colors theme creation to calculate text and textOnBrand correctly when background is dark

--- a/src/particles/media/component.tsx
+++ b/src/particles/media/component.tsx
@@ -17,24 +17,31 @@ export interface IMediaProps extends IComponentProps<IMediaTheme> {
   isLazyLoadable?: boolean;
 }
 
+const getExtension = (url: string): string => {
+  // NOTE(krishan711): the url is only used to check the type so it doesn't matter if it's actually the correct url or not (for now).
+  const source = new URL(url, typeof window !== 'undefined' && window?.location ? window.location.href : 'https://kibalabs.com');
+  const fileExtension = source.pathname.split('.').pop()?.toLowerCase() || '';
+  return fileExtension;
+};
+
 export const Media = (props: IMediaProps): React.ReactElement => {
   const [mediaType, setMediaType] = React.useState<string | null>(null);
   const isVideo = React.useMemo((): boolean => {
     if (!props.source) {
       return false;
     }
-    // NOTE(krishan711): the url is only used to check the type so it doesn't matter if it's actually the correct url or not (for now).
-    const source = new URL(props.source, typeof window !== 'undefined' && window?.location ? window.location.href : 'https://kibalabs.com');
-    const fileExtension = source.pathname.split('.').pop()?.toLowerCase() || '';
+    const fileExtension = getExtension(props.source);
     return fileExtension === 'mp4' || fileExtension === 'webm' || fileExtension === 'ogg';
   }, [props.source]);
 
-  const isImage = (url: string) => {
+  const isImage = React.useMemo((): boolean => {
+    if (!props.source) {
+      return false;
+    }
     const imageType = new Set(['png', 'jpg', 'gif', 'jpeg', 'tif', 'tiff', 'raw']);
-    const source = new URL(url, typeof window !== 'undefined' && window?.location ? window.location.href : 'https://kibalabs.com');
-    const fileExtension = source.pathname.split('.').pop()?.toLowerCase() || '';
+    const fileExtension = getExtension(props.source);
     return imageType.has(fileExtension);
-  };
+  }, [props.source]);
 
   React.useEffect((): void => {
     if (!props.source) {
@@ -42,8 +49,12 @@ export const Media = (props: IMediaProps): React.ReactElement => {
       return;
     }
 
-    if (isImage(props.source)) {
+    if (isImage) {
       setMediaType('image');
+      return;
+    }
+    if (isVideo) {
+      setMediaType('video');
       return;
     }
     fetch(props.source, { method: 'HEAD' })
@@ -67,7 +78,7 @@ export const Media = (props: IMediaProps): React.ReactElement => {
         console.error(error);
         setMediaType(null);
       });
-  }, [props.source]);
+  }, [props.source, isVideo, isImage]);
 
   return (isVideo || mediaType === 'video') ? (
     <Video shouldShowControls={false} shouldLoop={true} shouldMute={true} shouldAutoplay={true} {...props} />

--- a/src/particles/media/component.tsx
+++ b/src/particles/media/component.tsx
@@ -30,17 +30,18 @@ export const Media = (props: IMediaProps): React.ReactElement => {
     if (!props.source) {
       return false;
     }
+    const videoTypes = new Set(['mp4', 'webm', 'ogg']);
     const fileExtension = getExtension(props.source);
-    return fileExtension === 'mp4' || fileExtension === 'webm' || fileExtension === 'ogg';
+    return videoTypes.has(fileExtension);
   }, [props.source]);
 
   const isImage = React.useMemo((): boolean => {
     if (!props.source) {
       return false;
     }
-    const imageType = new Set(['png', 'jpg', 'gif', 'jpeg', 'tif', 'tiff', 'raw']);
+    const imageTypes = new Set(['png', 'jpg', 'gif', 'jpeg', 'tif', 'tiff', 'raw']);
     const fileExtension = getExtension(props.source);
-    return imageType.has(fileExtension);
+    return imageTypes.has(fileExtension);
   }, [props.source]);
 
   React.useEffect((): void => {

--- a/src/particles/media/component.tsx
+++ b/src/particles/media/component.tsx
@@ -29,9 +29,21 @@ export const Media = (props: IMediaProps): React.ReactElement => {
     return fileExtension === 'mp4' || fileExtension === 'webm' || fileExtension === 'ogg';
   }, [props.source]);
 
+  const isImage = (url: string) => {
+    const imageType = new Set(['png', 'jpg', 'gif', 'jpeg', 'tif', 'tiff', 'raw']);
+    const source = new URL(url, typeof window !== 'undefined' && window?.location ? window.location.href : 'https://kibalabs.com');
+    const fileExtension = source.pathname.split('.').pop()?.toLowerCase() || '';
+    return imageType.has(fileExtension);
+  };
+
   React.useEffect((): void => {
     if (!props.source) {
       setMediaType(null);
+      return;
+    }
+
+    if (isImage(props.source)) {
+      setMediaType('image');
       return;
     }
     fetch(props.source, { method: 'HEAD' })

--- a/src/particles/media/documentation.stories.mdx
+++ b/src/particles/media/documentation.stories.mdx
@@ -64,6 +64,14 @@ export const Template = (args) => (
   </Story>
 </Canvas>
 
+<Canvas>
+  <Story name='Link With Extension'>
+    <Box height={'500px'}>
+     <Media source='https://storage.googleapis.com/7981b604-d28c-4982-ac3f-0f9c61dc6e1d/3883.0001.png' />
+    </Box>
+  </Story>
+</Canvas>
+
 ### Theming
 
 TODO

--- a/src/particles/media/documentation.stories.mdx
+++ b/src/particles/media/documentation.stories.mdx
@@ -65,7 +65,7 @@ export const Template = (args) => (
 </Canvas>
 
 <Canvas>
-  <Story name='Link With Extension'>
+  <Story name='Image With Extension'>
     <Box height={'500px'}>
      <Media source='https://storage.googleapis.com/7981b604-d28c-4982-ac3f-0f9c61dc6e1d/3883.0001.png' />
     </Box>


### PR DESCRIPTION


## Description
if the image url has an extension e.g.png it should trust that extension. Only if it doesn't have an extension try the other method of fetching its content-type.

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
