### PR TITLE
Fix: update how Media detects content-type to use GET request if HEAD fails

### DIFF
--- a/src/particles/media/component.tsx
+++ b/src/particles/media/component.tsx
@@ -1,3 +1,4 @@
+import { KibaException, KibaResponse } from '@kibalabs/core';
 import React from 'react';
 
 import { defaultComponentProps, IComponentProps, ThemeType, WebView } from '../..';
@@ -28,8 +29,27 @@ const getExtension = (url: string): string => {
   return fileExtension;
 };
 
+const getContentType = (source: string, useGet = false): Promise<string | null> => {
+  return fetch(source, { method: useGet ? 'GET' : 'HEAD', redirect: 'follow' })
+    .then((response: Response): string | null => {
+      if (response.status >= 400) {
+        throw new KibaException(response.message || 'Failed to fetch', response.status);
+      }
+      const contentType = response.headers.get('Content-Type');
+      if (!contentType) {
+        return null;
+      }
+      const contentTypeParts = contentType.split('/');
+      if (contentTypeParts.length === 0) {
+        return null;
+      }
+      return contentTypeParts[0];
+    });
+}
+
 export const Media = (props: IMediaProps): React.ReactElement => {
-  const [mediaType, setMediaType] = React.useState<string | null>(null);
+  const [mediaType, setMediaType] = React.useState<string | null | undefined>(undefined);
+
   const isVideo = React.useMemo((): boolean => {
     if (!props.source) {
       return false;
@@ -48,7 +68,7 @@ export const Media = (props: IMediaProps): React.ReactElement => {
     return imageTypes.has(fileExtension);
   }, [props.source]);
 
-  React.useEffect((): void => {
+  const updateContentType = React.useCallback(async (): Promise<void> => {
     if (!props.source) {
       setMediaType(null);
       return;
@@ -62,28 +82,24 @@ export const Media = (props: IMediaProps): React.ReactElement => {
       setMediaType('video');
       return;
     }
-    fetch(props.source, { method: 'HEAD', redirect: 'follow' })
-      .then((response: Response) => {
-        if (response.status >= 400) {
-          throw new Error(`Failed to fetch content type: ${response}`);
-        }
-        const contentType = response.headers.get('Content-Type');
-        if (!contentType) {
-          setMediaType(null);
-          return;
-        }
-        const contentTypeParts = contentType.split('/');
-        if (contentTypeParts.length === 0) {
-          setMediaType(null);
-          return;
-        }
-        setMediaType(contentTypeParts[0]);
-      })
-      .catch((error: Error) => {
+    try {
+      const contentType = await getContentType(props.source);
+      setMediaType(contentType);
+    } catch (error: unknown) {
+      console.error(error);
+      try {
+        const contentType = await getContentType(props.source, true);
+        setMediaType(contentType);
+      } catch (error: unknown) {
         console.error(error);
         setMediaType(null);
-      });
-  }, [props.source, isVideo, isImage]);
+      }
+    };
+  }, [props.source, isVideo, isImage])
+
+  React.useEffect((): void => {
+    updateContentType();
+  }, [updateContentType]);
 
   return (isVideo || mediaType === 'video') ? (
     <Video shouldShowControls={false} shouldLoop={true} shouldMute={true} shouldAutoplay={true} {...props} />


### PR DESCRIPTION
<!--- Title format: [Feature | Fix | Task#]: <summary of your changes> -->

## Description

<!--- Describe your changes -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots:

<!--- If not relevant delete the sub-heading above -->

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
