### PR TITLE
Fix: Changed GlobalCSS to not stop body scrolling on webkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - [MINOR] Added `onFrameClicked` to `SingleLineInput`
 - [MINOR] Added `iconRight` and `iconLeft` to `InputFrame`
 - [MINOR] Added `isScrollableVertically` and `isScrollableHorizontally` and `shouldMatchAnchorWidth` and `shouldMatchAnchorHeight` to `Portal`
+- [MAJOR] Changed GlobalCSS to not stop body scrolling on webkit
 
 ### Removed
 

--- a/src/app/globalCss.tsx
+++ b/src/app/globalCss.tsx
@@ -38,9 +38,10 @@ export const GlobalCss = createGlobalStyle<IGlobalCssProps>`
     }
 
     // NOTE(krishan711): for ios only disable all body scrolling
-    _::-webkit-full-page-media, _:future, :root body {
-      overflow: hidden;
-    }
+    // NOTE(krishan711): disabled cos it wasnt working on safari, not sure what the answer is here
+    // _::-webkit-full-page-media, _:future, :root body {
+    //   overflow: hidden;
+    // }
 
     #root {
       width: 100%;


### PR DESCRIPTION
<!--- Title format: [Feature | Fix | Task#]: <summary of your changes> -->

## Description

<!--- Describe your changes -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots:

<!--- If not relevant delete the sub-heading above -->

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
